### PR TITLE
fix(build): workaround for next build hanging on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,6 @@
   command   = "npm run build"
   functions = "out_functions"
   publish   = "out_publish"
+
+[build.environment]
+  CIRCLE_NODE_TOTAL = "1"


### PR DESCRIPTION
Related to https://community.netlify.com/t/nextjs-website-wont-build/27365

I believe I found a workaround for the build hanging by limiting `next` cpu count.
I think the relevant code is:
https://github.com/vercel/next.js/blob/17b91e7c76711308707bc8ab3308376af98170e6/packages/next/build/index.ts#L745
https://github.com/vercel/next.js/blob/17b91e7c76711308707bc8ab3308376af98170e6/packages/next/next-server/server/config.ts#L46

I couldn't find a better way to control the cpu count :(