### PR TITLE
Fix Hero section responsiveness

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,7 +1,7 @@
 const Hero = () => (
   <>
     <div className="bg-gray-800 pb-44 max-md:pb-12">
-      <div className="relative max-xl:max-w-4xl max-w-7xl mx-auto pt-6 pb-6 flex justify-between max-md:flex-col max-md:justify-center max-md:items-center hero">
+      <div className="relative max-xl:max-w-4xl max-w-7xl mx-auto pt-6 pb-6 pl-8 flex justify-between max-md:flex-col max-md:justify-center max-md:items-center hero">
         <div className="flex justify-center flex-col">
           <h1 className="text-gray-200 text-3xl max-md:text-center font-bold">
             Blender Resources
@@ -16,6 +16,7 @@ const Hero = () => (
         <img src="/hero.png" className="hero-image" />
       </div>
     </div>
+
     <div className="relative">
       <div className="custom-shape-divider-bottom-1607292598">
         <svg


### PR DESCRIPTION
This would resolve #18 when merged.

This PR contains an addition of left padding to the Hero text at a medium display width to avoid it aligning to the left without any padding.

See screenshot below:
![Screenshot from 2020-12-13 08-16-41](https://user-images.githubusercontent.com/29664439/102006051-2d1b2900-3d1e-11eb-8b78-8ac7aead2ef5.png)
